### PR TITLE
Fixes #11 combine bank name, alias and location search

### DIFF
--- a/bank-info-fe/src/hooks/useFilteredBanks.js
+++ b/bank-info-fe/src/hooks/useFilteredBanks.js
@@ -20,28 +20,35 @@ function useFilteredBanks(
     if (!searchTerm) {
       return banks;
     }
-    const search = searchTerm.toLowerCase();
+    const searchWords = searchTerm.toLowerCase().split(" ");
+
+    function matchesSearch(text, strictEquality = false) {
+      const matchFunc = strictEquality ? "every" : "some";
+      return searchWords[matchFunc](function (word) {
+        return text?.toLowerCase().includes(word);
+      });
+    }
 
     function matchedAlias(bank) {
       return bank?.aliases?.some(function (alias) {
-        return alias?.toLowerCase().includes(search);
+        return matchesSearch(alias, true);
       });
     }
 
     function matchedBank(bank) {
-      return bank?.bank_name?.toLowerCase().includes(search);
+      return matchesSearch(bank?.bank_name, true);
     }
 
     const filtered = banks.filter(function (bank) {
       const matchedBranch = bank?.branches?.some(function (branch) {
-        return branch?.branch_name?.toLowerCase().includes(search);
+        return matchesSearch(branch?.branch_name);
       });
       return matchedBank(bank) || matchedAlias(bank) || matchedBranch;
     });
 
     const formatted = filtered.map(function (bank) {
       let branches = bank?.branches?.filter(function (branch) {
-        return branch?.branch_name?.toLowerCase().includes(search);
+        return matchesSearch(branch?.branch_name);
       });
       if (matchedBank(bank) || matchedAlias(bank)) {
         branches = bank.branches;

--- a/bank-info-fe/src/utils/highlightText.js
+++ b/bank-info-fe/src/utils/highlightText.js
@@ -10,16 +10,21 @@ function highlightText(text, highlight) {
     return text;
   }
 
-  const parts = text.split(new RegExp(`(${highlight})`, "gi"));
-
+  const words = highlight.split(" ");
+  const regex = new RegExp(`(${words.join("|")})`, "gi");
+  const parts = text.split(regex);
   const result = parts.map(function (part, index) {
-    return part.toLowerCase() === highlight.toLowerCase() ? (
-      <span key={index} className="bg-yellow-300">
-        {part}
-      </span>
-    ) : (
-      part
-    );
+    const match = words.some(function (word) {
+      return part.toLowerCase() === word.toLowerCase();
+    });
+    if (match) {
+      return (
+        <span key={index} className="bg-yellow-300">
+          {part}
+        </span>
+      );
+    }
+    return part;
   });
 
   return result;


### PR DESCRIPTION
If you type `kcb ruiru` or `ruiru kcb` order doesn't really matter it will return `all` banks with `name`/`alias` kcb and all banks with `branches` in ruiru.

> Suggestion

An ideal solution would be to have a separate filter/dropdown for the bank name and the search for any location where selected bank has a branch. This way the user can select the bank name and the location separately. This will make the search more accurate and user-friendly since we have a lot of records to filter.